### PR TITLE
Professionalize Section Int. documents

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,28 @@
+# This file configures the continuous integration (CI) system on GitHub.
+# Introductory materials can be found here: https://docs.github.com/en/actions/learn-github-actions/understanding-github-actions.
+# Documentation for editing this file can be found here: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions
+
+name: Tests
+
+# by default, give the GITHUB_TOKEN no permissions
+# See https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/controlling-permissions-for-github_token
+permissions: { }
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  lint:
+    name: Lint
+    permissions:
+      contents: read
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      # so far, this is just applied to Section Int. could apply in general later.
+      - name: Lint markdown
+        run: npx --yes prettier --check --prose-wrap always docs/internationalisation/*.md

--- a/docs/internationalisation/intro.md
+++ b/docs/internationalisation/intro.md
@@ -5,38 +5,68 @@ sidebar_position: 1
 
 # International Engagement
 
-The International Engagement section addresses internationalization as a key cross-cutting issue in science and as a strategic priority for NFDI since the association was founded. It coordinates NFDI's interaction with European and international communities and contributes to a coordinated approach to international activities. The section creates structures and working relationships to systematically involve relevant external actors and support cooperation within the NFDI. In addition, it acts as an interface for contextualizing European and international initiatives and promotes exchange between NFDI consortia, sections, and external partners in the international environment.
+The International Engagement section addresses internationalization as a key
+cross-cutting issue in science and as a strategic priority for NFDI since the
+association was founded. It coordinates NFDI's interaction with European and
+international communities and contributes to a coordinated approach to
+international activities. The section creates structures and working
+relationships to systematically involve relevant external actors and support
+cooperation within the NFDI. In addition, it acts as an interface for
+contextualizing European and international initiatives and promotes exchange
+between NFDI consortia, sections, and external partners in the international
+environment.
 
 ## Mission
 
-The section is committed to creating sustainable conditions for the effective European and international integration of the NFDI. To this end, structured overviews and decision-making bases are being developed to enable the consortia to strategically prioritize international activities and implement them in a targeted manner.
+The section is committed to creating sustainable conditions for the effective
+European and international integration of the NFDI. To this end, structured
+overviews and decision-making bases are being developed to enable the consortia
+to strategically prioritize international activities and implement them in a
+targeted manner.
 
-A key focus is on the successful establishment of a **German national EOSC node** ([EOSC Node Germany](https://www.nfdi.de/eosc-node-germany/)) supported by the NFDI as a visible contribution to the European Open Science Cloud. In this context, the section supports the coordination of overarching framework conditions and promotes the active involvement of NFDI consortia in the further development of the EOSC federation.
+A key focus is on the successful establishment of a **German national EOSC
+node** ([EOSC Node Germany](https://www.nfdi.de/eosc-node-germany/)) supported
+by the NFDI as a visible contribution to the European Open Science Cloud. In
+this context, the section supports the coordination of overarching framework
+conditions and promotes the active involvement of NFDI consortia in the further
+development of the EOSC federation.
 
-In addition, it is a key concern of the section to systematically leverage experience gained from participation in European and international infrastructures. On this basis, transferable models and working approaches are to be developed that support the sustainable design of further international cooperation by the NFDI.
+In addition, it is a key concern of the section to systematically leverage
+experience gained from participation in European and international
+infrastructures. On this basis, transferable models and working approaches are
+to be developed that support the sustainable design of further international
+cooperation by the NFDI.
 
 ## Working Groups
 
-The working groups within the International Engagement section are derived from the tasks defined in the [Section Concept](https://zenodo.org/records/18459748).
+The working groups within the International Engagement section are derived from
+the tasks defined in the [Section Concept](https://zenodo.org/records/18459748).
 
-| Working Group | Focus |
-|---------------|-------|
-| [Surveying the European and International Landscape](./wg_landscape_survey) | Mapping NFDI interactions with relevant international entities; operationalizing into an actionable workflow |
-| [Supporting the Development of EOSC Node Germany](./wg_eosc_node) | Serving as NFDI point of contact for EOSC Node Germany; connecting NFDI services to the EOSC federation |
-| [Continuation of Internationalization and Outreach](./wg_outreach) | Building a reusable framework from EOSC experience; supporting consortia in subsequent international engagements |
+| Working Group                                                               | Focus                                                                                                            |
+| --------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------- |
+| [Surveying the European and International Landscape](./wg_landscape_survey) | Mapping NFDI interactions with relevant international entities; operationalizing into an actionable workflow     |
+| [Supporting the Development of EOSC Node Germany](./wg_eosc_node)           | Serving as NFDI point of contact for EOSC Node Germany; connecting NFDI services to the EOSC federation          |
+| [Continuation of Internationalization and Outreach](./wg_outreach)          | Building a reusable framework from EOSC experience; supporting consortia in subsequent international engagements |
 
 ## Section Concept
 
-The section concept defines the goals, structure, and working programme of the International Engagement section.
+The section concept defines the goals, structure, and working programme of the
+International Engagement section.
 
-- **Title:** Section Concept for establishing a section within the association German National Research Data Infrastructure (NFDI) — Section International Engagement
+- **Title:** Section Concept for establishing a section within the association
+  German National Research Data Infrastructure (NFDI) — Section International
+  Engagement
 - **Published:** February 2026
-- **Authors:** Charles Tapley Hoyt, Alexandra Büttner, Christian Busse, Andreas Haungs, Lukas Jansen, Rebecca Kröhler, Najla Rettberg, Nanette Rißler-Pipka, Ahmed Saleh, Christian Schäfer-Neth, Thomas Schörner, Hendrik Seitz-Moskaliuk, Ulrik Stervbo, Heiko Weber, Jos van Wezel, Wilma Wolf
-- **Download:** [zenodo.org/records/18459748](https://zenodo.org/records/18459748)
+- **Authors:** Charles Tapley Hoyt, Alexandra Büttner, Christian Busse, Andreas
+  Haungs, Lukas Jansen, Rebecca Kröhler, Najla Rettberg, Nanette Rißler-Pipka,
+  Ahmed Saleh, Christian Schäfer-Neth, Thomas Schörner, Hendrik Seitz-Moskaliuk,
+  Ulrik Stervbo, Heiko Weber, Jos van Wezel, Wilma Wolf
+- **Download:**
+  [zenodo.org/records/18459748](https://zenodo.org/records/18459748)
 
 ## Mailing List and Registration
 
-- Mailing list: [section-int.lists.nfdi.de](https://lists.nfdi.de/postorius/lists/section-int.lists.nfdi.de/)
-- Registration for section participation: [nfdi.de/registration-for-participation-in-the-sections](https://www.nfdi.de/registration-for-participation-in-the-sections/?lang=en)
-
-
+- Mailing list:
+  [section-int.lists.nfdi.de](https://lists.nfdi.de/postorius/lists/section-int.lists.nfdi.de/)
+- Registration for section participation:
+  [nfdi.de/registration-for-participation-in-the-sections](https://www.nfdi.de/registration-for-participation-in-the-sections/?lang=en)

--- a/docs/internationalisation/wg_eosc_node.md
+++ b/docs/internationalisation/wg_eosc_node.md
@@ -5,23 +5,34 @@ sidebar_position: 3
 
 # Working Group Supporting the Development of EOSC Node Germany
 
-The European Open Science Cloud (EOSC) is establishing a **federation of national and thematic nodes** with the aim of enabling access to digital resources and services across borders and disciplines. Because NFDI is developing similar capabilities on a national level, the NFDI has the goal of:
+The European Open Science Cloud (EOSC) is establishing a **federation of
+national and thematic nodes** with the aim of enabling access to digital
+resources and services across borders and disciplines. Because NFDI is
+developing similar capabilities on a national level, the NFDI has the goal of:
 
-1. Connecting suitable NFDI services via the **EOSC Node Germany** to the EOSC federation
+1. Connecting suitable NFDI services via the **EOSC Node Germany** to the EOSC
+   federation
 2. Participating in the early development of the agenda of the EOSC federation
 
-Section Int serves as the **central point of contact** for all matters concerning the establishment of the EOSC Node Germany and gives the NFDI community the possibility to directly support the development of the node.
+Section Int serves as the **central point of contact** for all matters
+concerning the establishment of the EOSC Node Germany and gives the NFDI
+community the possibility to directly support the development of the node.
 
 ## About EOSC Node Germany
 
-EOSC Node Germany is the German national node of the European Open Science Cloud. It is supported by the NFDI as a visible and substantive contribution to the EOSC federation.
+EOSC Node Germany is the German national node of the European Open Science
+Cloud. It is supported by the NFDI as a visible and substantive contribution to
+the EOSC federation.
 
-- NFDI page on EOSC Node Germany: [nfdi.de/eosc-node-germany](https://www.nfdi.de/eosc-node-germany/)
+- NFDI page on EOSC Node Germany:
+  [nfdi.de/eosc-node-germany](https://www.nfdi.de/eosc-node-germany/)
 
 ## Resources
 
-- Section Concept: [zenodo.org/records/18459748](https://zenodo.org/records/18459748)
+- Section Concept:
+  [zenodo.org/records/18459748](https://zenodo.org/records/18459748)
 
 ## Mailing List
 
-- Subscribe / Archive: [section-int.lists.nfdi.de](https://lists.nfdi.de/postorius/lists/section-int.lists.nfdi.de/)
+- Subscribe / Archive:
+  [section-int.lists.nfdi.de](https://lists.nfdi.de/postorius/lists/section-int.lists.nfdi.de/)

--- a/docs/internationalisation/wg_landscape_survey.md
+++ b/docs/internationalisation/wg_landscape_survey.md
@@ -3,23 +3,33 @@ title: WG Landscaping and Outreach
 sidebar_position: 2
 ---
 
-# Working Group for for Landscaping and Outreach
+# Working Group for Landscaping and Outreach
 
-This working group systematically maps the existing and aspirational interactions between the NFDI — at the level of individual researchers, organisations, and consortia — and relevant European and international entities. These entities include working groups, projects, organisations, funders, research infrastructures, and other stakeholders in the international research data landscape.
+This working group systematically maps the existing and aspirational
+interactions between the NFDI — at the level of individual researchers,
+organizations, and consortia — and relevant European and international entities.
+These entities include working groups, projects, organizations, funders,
+research infrastructures, and other stakeholders in the international research
+data landscape.
 
 ## Goals
 
-- **Identify** existing and aspirational interactions between NFDI actors and relevant international entities
+- **Identify** existing and aspirational interactions between NFDI actors and
+  relevant international entities
 - **Operationalize** the landscape into a structured workflow that:
   - Suggests relevant external entities for NFDI to interact with
   - Summarizes the purpose and important context of each interaction
-  - Identifies the appropriate individuals or groups within NFDI to mediate the interaction
+  - Identifies the appropriate individuals or groups within NFDI to mediate the
+    interaction
 
-The resulting landscape overview will serve as a shared resource for all NFDI consortia and sections, enabling strategic prioritization of international activities.
+The resulting landscape overview will serve as a shared resource for all NFDI
+consortia and sections, enabling strategic prioritization of international
+activities.
 
 ## Resources
 
-- Section Concept: [zenodo.org/records/18459748](https://zenodo.org/records/18459748)
+- Section Concept:
+  [zenodo.org/records/18459748](https://zenodo.org/records/18459748)
 
 ## Mailing List
 
@@ -29,5 +39,5 @@ The resulting landscape overview will serve as a shared resource for all NFDI co
 ## Coordinators
 
 | Name                | Affiliation            | Email                          |
-|---------------------|------------------------|--------------------------------|
+| ------------------- | ---------------------- | ------------------------------ |
 | Charles Tapley Hoyt | RWTH Aachen University | charles.hoyt@ac.rwth-aachen.de |

--- a/docs/internationalisation/wg_outreach.md
+++ b/docs/internationalisation/wg_outreach.md
@@ -5,22 +5,33 @@ sidebar_position: 4
 
 # Working Group Continuation of Internationalization and Outreach
 
-This working group builds on the experiences gained in the [EOSC Node Germany](./wg_eosc_node) effort to create a **reusable framework** that supports NFDI consortia in developing and nurturing European and international interactions more broadly.
+This working group builds on the experiences gained in the
+[EOSC Node Germany](./wg_eosc_node) effort to create a **reusable framework**
+that supports NFDI consortia in developing and nurturing European and
+international interactions more broadly.
 
 ## Goals
 
-- **Collect** experiences and lessons learned from supporting the deployment of EOSC Node Germany
-- **Operationalize** these into a reusable framework that consortia can apply to future international engagements
-- **Support** NFDI consortia in identifying and pursuing a second and subsequent major international demonstrations — for example:
-  - Interactions between [ELIXIR](https://elixir-europe.org/) and the life and natural sciences NFDI consortia
+- **Collect** experiences and lessons learned from supporting the deployment of
+  EOSC Node Germany
+- **Operationalize** these into a reusable framework that consortia can apply to
+  future international engagements
+- **Support** NFDI consortia in identifying and pursuing a second and subsequent
+  major international demonstrations — for example:
+  - Interactions between [ELIXIR](https://elixir-europe.org/) and the life and
+    natural sciences NFDI consortia
   - Connections to other European research infrastructure networks and funders
 
-The framework developed by this working group aims to lower the barrier for NFDI consortia to engage internationally and to ensure that knowledge gained in one context can be transferred and reused across the NFDI.
+The framework developed by this working group aims to lower the barrier for NFDI
+consortia to engage internationally and to ensure that knowledge gained in one
+context can be transferred and reused across the NFDI.
 
 ## Resources
 
-- Section Concept: [zenodo.org/records/18459748](https://zenodo.org/records/18459748)
+- Section Concept:
+  [zenodo.org/records/18459748](https://zenodo.org/records/18459748)
 
 ## Mailing List
 
-- Subscribe / Archive: [section-int.lists.nfdi.de](https://lists.nfdi.de/postorius/lists/section-int.lists.nfdi.de/)
+- Subscribe / Archive:
+  [section-int.lists.nfdi.de](https://lists.nfdi.de/postorius/lists/section-int.lists.nfdi.de/)


### PR DESCRIPTION
We want the documentation about Section International Engagement to look as professional as possible.

Therefore, this PR applies standardized formatting to all markdown files for Section Int. This PR also adds a GitHub Actions configuration to run the linter to make sure that no pull request can be merged without first formatting markdown.

The Markdown files for Section Int. can be updated with the following:

```console
$ npx --yes prettier --check --prose-wrap always --write docs/internationalisation/*.md
```

Later, it might be desired to apply this to all sections, however, I am responsible for part of section int, so I am only touching our documents in this PR.