### PR TITLE
Fix link to blog folder in news entry tutorial

### DIFF
--- a/docs/tutorial/news-entry.md
+++ b/docs/tutorial/news-entry.md
@@ -3,7 +3,7 @@ title: Create and Edit a News Entry
 sidebar_position: 4
 ---
 
-Creating and editing [News](https://nfdi-de.github.io/nfdi-sections/blog) works just like [creating pages](./create-page.md) and [editing pages](./edit-page.md), but you have to edit files in the folder /blog and the header info should be e.g.
+Creating and editing [News](https://nfdi-de.github.io/nfdi-sections/blog) works just like [creating pages](./create-page.md) and [editing pages](./edit-page.md), but you have to edit files in the folder [/blog](https://github.com/nfdi-de/nfdi-sections/tree/main/blog) and the header info should be e.g.
 ```
 ---
 slug: section-meta-meeting-march-2026


### PR DESCRIPTION
Updated link to the blog folder in the news entry tutorial.