### PR TITLE
Fix typos in review process documentation

### DIFF
--- a/docs/tutorial/review-process.md
+++ b/docs/tutorial/review-process.md
@@ -3,7 +3,7 @@ title: Reviewing and Publishing
 sidebar_position: 7
 ---
 
-This process applies to any content: new pages, changed panges, calendar entries, and News entries. Reviewing can be done by anyone but the author of the proposed chamges. Only after it has been positively reviewd, a proposed change can be published. 
+This process applies to any content: new pages, changed pages, calendar entries, and news entries. Reviewing can be done by anyone but the author of the proposed changes. Only after it has been positively reviewd, a proposed change can be published. 
 
 ### Reviewing
 
@@ -19,5 +19,5 @@ This process applies to any content: new pages, changed panges, calendar entries
 
 ### Publishing
 * After a proposed change has at least one "Approve" review, a button "Squash and merge" appears. Click this Button to publish the content.
-* It ma take up to two minutes until the changes become visible in the [Website](https://nfdi-de.github.io/nfdi-sections/) 
+* It may take up to two minutes until the changes become visible in the [Website](https://nfdi-de.github.io/nfdi-sections/) 
 


### PR DESCRIPTION
Correct typos and improve clarity in the review process documentation.